### PR TITLE
Specify all protocol arities in single definition.

### DIFF
--- a/src/clj_leveldb.clj
+++ b/src/clj_leveldb.clj
@@ -112,13 +112,11 @@
 
 (defprotocol ILevelDB
   (^:private ^DB db-  [_])
-  (^:private batch- [_])
-  (^:private iterator- [_])
+  (^:private batch- [_] [_ options])
+  (^:private iterator- [_] [_ start end])
   (^:private get- [_ k])
   (^:private put- [_ k v options])
   (^:private del- [_ k options])
-  (^:private iterator- [_ start end])
-  (^:private batch- [_ options])
   (^:private snapshot- [_]))
 
 (defrecord Snapshot


### PR DESCRIPTION
Resolves "java.lang.IllegalArgumentException: Function iterator- in protocol ILevelDB was redefined" exception when compiled with Clojure 1.6.0
