### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a self-contained wrapper around [LevelDB](https://code.google.com/p/leve
 To create or access a database, use `clj-leveldb/create-db`:
 
 ```clj
-clj-leveldb> (def db (create-db "/tmp/leveldb"))
+clj-leveldb> (def db (create-db "/tmp/leveldb" {}))
 #'clj-leveldb/db
 ```
 


### PR DESCRIPTION
This commit fixes a typo in the README: `create-db` _requires_ two
arguments (a database and an options map), but the README example
includes only the former argument.  This causes an `ArityException`:

```
ArityException Wrong number of args (1) passed to: clj-leveldb$create-db
```

This commit fixes the README example to have the right number of args.
