### PR TITLE
Idea for adding a "batch" interface to combine puts and deletes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a self-contained wrapper around [LevelDB](https://code.google.com/p/leve
 ### basic usage
 
 ```clj
-[factual/clj-leveldb "0.1.1"]
+[factual/clj-leveldb "0.1.2"]
 ```
 
 To create or access a database, use `clj-leveldb/create-db`:
@@ -13,7 +13,7 @@ clj-leveldb> (def db (create-db "/tmp/leveldb" {}))
 #'clj-leveldb/db
 ```
 
-This database object can now be used with `clj-leveldb/get`, `put`, `delete`, and `iterator`.
+This database object can now be used with `clj-leveldb/get`, `put`, `delete`, `batch`, and `iterator`.
 
 ```clj
 clj-leveldb> (put db "a" "b")
@@ -42,6 +42,12 @@ clj-leveldb> (put db "a" "b" "c" "d" "e" "f")
 nil
 clj-leveldb> (delete db "a" "c" "e")
 nil
+```
+
+If you need to batch a collection of puts and deletes, use `batch`:
+
+```clj
+clj-leveldb> (batch db {:put ["a" "b" "c" "d"] :delete ["j" "k" "l"]})
 ```
 
 We can also get a sequence of all key/value pairs, either in the entire database or within a given range using `iterator`:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factual/clj-leveldb "0.1.1"
+(defproject factual/clj-leveldb "0.1.2"
   :description "an idiomatic wrapper for LevelDB"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/clj_leveldb.clj
+++ b/src/clj_leveldb.clj
@@ -391,3 +391,16 @@
          (.compactRange (db- db)
            (bs/to-byte-array (encoder start))
            (bs/to-byte-array (encoder end)))))))
+
+(defn batch
+  "Batch a collection of put and/or delete operations into the supplied `db`.
+   Takes a map of the form `{:put [key1 value1 key2 value2] :delete [key3 key4]}`.
+   If `:put` key is provided, it must contain an even-length sequence of alternating keys and values."
+  ([db] )
+  ([db {puts :put deletes :delete}]
+   (assert (even? (count puts)) ":put option requires even number of keys and values.")
+   (with-open [^Batch batch (batch- db nil)]
+     (doseq [[k v] (partition 2 puts)]
+       (put- batch k v nil))
+     (doseq [k deletes]
+       (del- batch k nil)))))

--- a/test/clj_leveldb_test.clj
+++ b/test/clj_leveldb_test.clj
@@ -59,4 +59,28 @@
     (is (= nil (l/get db :a)))
     (is (= :b (l/get snapshot :a))))
 
-  (l/compact db))
+  (l/compact db)
+
+  (l/delete db :a :b :z :y)
+
+  (l/put db :j :k :l :m)
+  (is (= :k (l/get db :j)))
+  (is (= :m (l/get db :l)))
+
+  (l/batch db)
+  (is (= :k (l/get db :j)))
+  (is (= :m (l/get db :l)))
+  (l/batch db {:put [:r :s :t :u]})
+  (is (= :s (l/get db :r)))
+  (is (= :u (l/get db :t)))
+  (l/batch db {:delete [:r :t]})
+  (is (= nil (l/get db :r)))
+  (is (= nil (l/get db :t)))
+
+  (l/batch db {:put [:a :b :c :d]
+               :delete [:j :l]})
+  (is (= :b (l/get db :a)))
+  (is (= :d (l/get db :c)))
+  (is (= nil (l/get db :j)))
+  (is (= nil (l/get db :l)))
+  (is (thrown? AssertionError (l/batch db {:put [:a]}))))


### PR DESCRIPTION
First of all, thanks for providing this library! I've been using it in a project and it's been very helpful.

A few times I've found myself wanting to be able to batch puts and deletes together -- as far as I could tell there isn't currently an interface for this, but thanks to the Batch record y'all had written it was pretty easy to add.

I wrote it to accept a sequence of keys and values as the option for `:put` since I felt like that matched the current interface to `put` more cleanly. But it could also be done with a map (`(batch db {:put {:k1 :v1 :k2 :v2})`) if you think that is cleaner.