### PR TITLE
due to an out of date version of clj-tuple being included via the now…

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.fusesource.leveldbjni/leveldbjni-all "1.8"]
                  [org.iq80.leveldb/leveldb-api "0.7"]
-                 [byte-streams "0.1.13"]]
+                 [byte-streams "0.1.13" :exclusions [clj-tuple]];old byte-streams dep is causing clojure 1.9+ to fail. remove the clj-tuple exclude and include when byte-streams can be updated
+                 [clj-tuple "0.2.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
                                   [criterium "0.4.3"]
                                   [codox-md "0.2.0" :exclusions [org.clojure/clojure]]]}}


### PR DESCRIPTION
… out of date byte-streams dependency, clj-leveldb will fail at runtime when being required on clojure 1.9+. This is because of a newly enforced spec conform on the defn- function which the out of date clj-tuple is calling incorrectly.

  excluding the old clj-tuple and including the latest addresses the issue.
